### PR TITLE
making only direct children of slide block elements

### DIFF
--- a/css/crellyslider.css
+++ b/css/crellyslider.css
@@ -51,7 +51,7 @@
 	overflow: hidden;
 }
 
-.crellyslider > .cs-slides > .cs-slide * {
+.crellyslider > .cs-slides > .cs-slide > * {
 	display: block;
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
All slide elements are becomming block elements, this is causing problems with elements like `<i>`, `<a>`, `<span>`, `<sup>`, etc.
I think just the direct children of a slide should be block elements and leave the grandchildren elements with their default displays.
Then i suggest the rule `.crellyslider > .cs-slides > .cs-slide * {`, at line 54, should be `.crellyslider > .cs-slides > .cs-slide > * {`.