### PR TITLE
Fixed newlines getting misinterpreted as linebreaks in text-elements

### DIFF
--- a/wordpress/frontend.php
+++ b/wordpress/frontend.php
@@ -123,8 +123,8 @@ class CrellySliderFrontend {
 							'data-left="' . esc_attr($element->data_left) . '"' . "\n" .
 							'data-time="' . esc_attr($element->data_time) . '"' . "\n";
 						}
-						$output .= '>' . "\n" .
-						stripslashes($element->inner_html) . "\n" .
+						$output .= '>' .
+						stripslashes($element->inner_html) .
 						'</div>' . "\n";
 					break;
 


### PR DESCRIPTION
The `\n` newlines in text-elements are getting filtered to actual `<br>` tags by wordpress.
(Releated to this issue: [https://wordpress.org/support/topic/tag-in-text-element/](https://wordpress.org/support/topic/tag-in-text-element/) )