### PR TITLE
line-height 'normal'

### DIFF
--- a/js/jquery.crellyslider.js
+++ b/js/jquery.crellyslider.js
@@ -463,9 +463,16 @@ var crellyslider_vimeo_api_ready = false;
 			element.data('font-size', parseFloat(element.css('font-size')));
 
 			if(element.css('line-height').slice(-2).toLowerCase() == 'px') {
+				// if pixel values are given, use those
 				element.data('line-height', parseFloat(element.css('line-height')));
 			}
+			else if(element.css('line-height') == 'normal') {
+				// if the browser returns 'normal' then use a default factor of 1.15 * font-size
+				// see: http://meyerweb.com/eric/thoughts/2008/05/06/line-height-abnormal/
+				element.data('line-height', getItemData(element, 'font-size') * 1.15);
+			}
 			else {
+				// otherwise assume that the returned value is a factor and multiply it with the font-size
 				element.data('line-height', parseFloat(element.css('line-height')) * getItemData(element, 'font-size'));
 			}
 


### PR DESCRIPTION
When no line-height is set on the element itself (or e.g. `inherit` is used), then the line-height is supplied by the browser. The default line-height in all browsers is `normal`.

Most browsers (FF, for example) return the actual px-value when queried. Some browsers, however, return the string `normal` (the current Chrome 62 for, example).

Trying to convert `normal` to float leads to the coefficient being 0 and thus a line-height of 0px.

The value `normal` usually computes to something between 1.0 and 1.2. This fix uses a value of 1.15 as the coefficient.

See http://meyerweb.com/eric/thoughts/2008/05/06/line-height-abnormal/ for even more details on this.

Best regards,
Daniel