### PR TITLE
only update schema if version changed

### DIFF
--- a/wordpress/tables.php
+++ b/wordpress/tables.php
@@ -14,10 +14,14 @@ class CrellySliderTables {
 
 	// Creates or updates all the tables
 	public static function setTables() {
-		self::setSlidersTable();
-		self::setSlidesTable();
-		self::setElementsTable();
-		self::setNoncesTable();
+		$cs_version = get_option( 'cs_version' );
+		// only update tables if version changed
+		if ( $cs_version != CS_VERSION ) {
+			self::setSlidersTable();
+			self::setSlidesTable();
+			self::setElementsTable();
+			self::setNoncesTable();
+		}
 	}
 
 	public static function setNoncesTable() {


### PR DESCRIPTION
Hey Fabio
I just found out, that this migration is being run on every request in the admin area of wordpress. this slowed down my website. How about only running this migration if the version of the plugin changed?